### PR TITLE
fix: tokenizes words when searching for specific triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,19 @@ For ease of use, you should create a Python 3 virtual environment and then use `
 pip install -r requirements.txt
 ```
 
+If you're more onto using `conda`, the following command will create an environment, activate it and install the requirements:
+
+```bash
+conda create -n dogpicsbot python=3.7
+conda activate dogpicsbot
+pip install -r requirements.txt
+```
+
 ## Installation
 
 Simply clone this repository, fetch the requirements on a virtual environment as stated above and then set a new environment variable named `DPB_TG_TOKEN` with your Telegram bot API token. If you don't have a valid token, [check this out](https://core.telegram.org/bots).
 
-Note that one feature (sending dog pictures freely through group chats on certain trigger words) requires the bot's Privacy Mode to be disabled (this can be done through @BotFather).
+Note that one feature (sending dog pictures freely through group chats on certain trigger words) requires the bot's Privacy Mode to be **disabled** (this can be done through @BotFather).
 
 ## Usage
 

--- a/bot.py
+++ b/bot.py
@@ -17,6 +17,9 @@ from telegram.ext import CommandHandler, Filters, MessageHandler, Updater
 
 
 class DogPicsBot:
+
+    TELEGRAM_GROUP = 'group'
+
     """
     A class to encapsulate all relevant methods of the Dog Pics
     Telegram bot.
@@ -168,26 +171,29 @@ class DogPicsBot:
         Checks if a message comes from a group. If that is not the case,
         or if the message includes a trigger word, replies with a dog picture.
         """
+        words = set(update.message.text.lower().split())
+        logging.debug(f'Received message: {update.message.text}')
+        logging.debug(f'Splitted words: {", ".join(words)}')
 
         # Possibility: received message mentions a specific breed
         breed = None
         for b in self.breeds:
-            if b in update.message.text.lower():
+            if b in words:
                 breed = b
                 break
         mentionsABreed = breed is not None
 
         # Easter Egg Possibility: has a fox emoji
-        hasFoxEmoji = any([x in update.message.text.lower() for x in self.fox_triggers])
+        hasFoxEmoji = any([x in words for x in self.fox_triggers])
 
         # Possibility: received a sad message
-        isSadMessage = any([x in update.message.text.lower() for x in self.sad_triggers])
+        isSadMessage = any([x in words for x in self.sad_triggers])
 
         # Possibility: received message mentions dogs
-        shouldTriggerPicture = any([x in update.message.text.lower() for x in self.dog_triggers])
+        shouldTriggerPicture = any([x in words for x in self.dog_triggers])
 
         # Possibility: it's a personal chat message
-        isPersonalChat = update.message.chat.type != 'group'
+        isPersonalChat = update.message.chat.type != self.TELEGRAM_GROUP
 
         if hasFoxEmoji:
             self.send_fox_picture(update, context)


### PR DESCRIPTION
At this moment, the bot sends dog pics for specific emotions (sadness, for example) whenever it finds any of the configured words on the message, even when any of those words where found _inside_ of another word on the text.

For example, the word `download` includes the _sad word_ `down`, but the message `My download of "The Legend of Zelda: Breath of the Wild" has started` was detected as a _sad message_, even when it's not sad at all!

This PR fixes that by tokenizing the lowercased text and comparing directly against the words on that set. It also improves the `#Installation` section of the README a little bit to include commands for anaconda users