### PR TITLE
Add new triggers for dogs and sad messages

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -84,6 +84,7 @@ class DogPicsBot:
             "dog",
             "perr",
             "lomito",
+            "pooch",
         ] + self.dog_emojis
 
         # Just like dog triggers, these will be checked against
@@ -97,11 +98,23 @@ class DogPicsBot:
         ]
 
         # Same as earlier triggers, but for sad messages
+        self.sad_spanish_triggers = [
+            "triste",
+            "afligido",
+            "lloro",
+            "deprimido",
+            "tusa",
+            "despech", # despechado, despechada, despecho
+        ]
+
         self.sad_triggers = [
             "😔",
+            "😞",
             "😢",
             "😭",
             "😓",
+            "😫",
+            "💔",
             "sad",
             "not good",
             "unhappy",
@@ -109,8 +122,7 @@ class DogPicsBot:
             "miserable",
             "down",
             "downhearted",
-            "triste",
-        ]
+        ] + self.sad_spanish_triggers
 
         # This environment variable should be set before using the bot
         self.token = os.environ.get("DPB_TG_TOKEN", "")
@@ -214,7 +226,11 @@ class DogPicsBot:
 
         # Possibility: received a sad message
         is_sad_message = any(
-            sad_trigger in words for sad_trigger in self.sad_triggers
+            any(
+                word.startswith(sad_trigger)
+                for word in words
+            )
+            for sad_trigger in self.sad_triggers
         )
 
         # Possibility: received message mentions dogs

--- a/tests.py
+++ b/tests.py
@@ -313,6 +313,7 @@ def test_handle_text_messages_for_private_message(
         "look! a! doggo!",
         "puppy!",
         "woof!",
+        "pooch!"
     ]
 )
 def test_handle_text_messages_for_group_message_with_dogs(
@@ -376,7 +377,13 @@ def test_handle_text_messages_for_group_message_without_dogs(
         "sad",
         "i'm really sad right now",
         "😢",
+        "😭😓",
+        "She left me 💔",
+        "I'm not gonna make it 😞"
         "mano, estoy triste",
+        "estoy despechado",
+        "ando deprimido",
+        "tengo tusa",
     ]
 )
 def test_handle_text_messages_for_sad_message(
@@ -483,6 +490,7 @@ def test_handle_text_messages_for_dog_sticker(
         "foxes are the best",
         "i saw a fennec the other day",
         "do you have a fox?",
+        "mira un zorro!"
     ]
 )
 def test_handle_text_messages_for_fox_reference(


### PR DESCRIPTION
## For dogs
Add new word "pooch".

## For sad messages
Add more sad Spanish triggers and more emojis.

### Bug
The bot wasn't supporting sad emojis followed by other sad emojis. I found that while testing _"despech"_ for _"despechado"/"despechada"_.

#### Bugfix
Replicate code used for dog triggers.